### PR TITLE
lightwaverf configuration from server and timeout on sendup

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A NodeJS library for controlling devices using the LightwaveRF Wi-Fi Link
 ### Initialize
 
     var LightwaveRF = require("lightwaverf");
-    var lw = new LightwaveRF({ip:"192.168.1.123"});
+    var lw = new LightwaveRF({ip:"192.168.1.123",email:"name@host.com",pin:"0123"});
 
 ### Turn a device on
 


### PR DESCRIPTION
Hi,

I'm working on an lightwaverf homekit plugin for homebridge based on my hap-nodjs lightwaverf accessory. For this I need to create homekit accessories that resemble the ones registered in lightwaverf. For this reason I included a method to obtain the server configuration.
Also homekit may send fast commands to the accessories that will cause it to skip commands. For this I added some timeout functionality.
Do you thing your module is the right place for this?

Roy